### PR TITLE
fixed regex statement

### DIFF
--- a/SteamBulkActivator/MainForm.cs
+++ b/SteamBulkActivator/MainForm.cs
@@ -249,7 +249,7 @@ namespace SteamBulkActivator
         private void addKeysToList(bool regexCheck = true)
         {
             var tempList = new List<string>();
-            string cdKeyPattern = @"(\w+\-)+\w+";
+            string cdKeyPattern = @"([A-Za-z0-9]+)-([A-Za-z0-9]+)-([A-Za-z0-9]+)";
             foreach (Match m in Regex.Matches(txtKeys.Text, cdKeyPattern))
             {
                 if (tempList.Contains(m.Value))


### PR DESCRIPTION
Current regex  statement will alert positive key on anything with a dash. This regex will only verify key if the key has characters between A-Z, z-z, or 0-0 in a double dash format (per key requirements on Steam website)

Total prevent extra text (like Total Warhammer: Cool DLC - Extra) from being accidentally brought in as a valid key